### PR TITLE
feat: dwm-systray

### DIFF
--- a/dwm-systray.diff
+++ b/dwm-systray.diff
@@ -1,0 +1,950 @@
+diff --git a/config.def.h b/config.def.h
+index b00e7cd..e8d4e46 100644
+--- a/config.def.h
++++ b/config.def.h
+@@ -25,6 +25,11 @@ dwm-xrdb-6.4.diff - xresource database colors
+ /* appearance */
+ static unsigned int borderpx        = 1;        /* border pixel of windows */
+ static unsigned int snap            = 32;       /* snap pixel */
++static const unsigned int systraypinning = 0;   /* 0: sloppy systray follows selected monitor, >0: pin systray to monitor X */
++static const unsigned int systrayonleft = 0;    /* 0: systray in the right corner, >0: systray on left of status text */
++static const unsigned int systrayspacing = 2;   /* systray spacing */
++static const int systraypinningfailfirst = 1;   /* 1: if pinning fails, display systray on the first monitor, False: display systray on the last monitor*/
++static const int showsystray        = 1;        /* 0 means no systray */
+ static const unsigned int gappih    = 20;       /* horiz inner gap between windows */
+ static const unsigned int gappiv    = 20;       /* vert inner gap between windows */
+ static const unsigned int gappoh    = 20;       /* horiz outer gap between windows and screen edge */
+diff --git a/dwm.c b/dwm.c
+index 7f7186d..1922eba 100644
+--- a/dwm.c
++++ b/dwm.c
+@@ -84,13 +84,28 @@
+                                 }
+ #define TRUNC(X,A,B)            (MAX((A), MIN((X), (B))))
+ 
++#define SYSTEM_TRAY_REQUEST_DOCK    0
++/* XEMBED messages */
++#define XEMBED_EMBEDDED_NOTIFY      0
++#define XEMBED_WINDOW_ACTIVATE      1
++#define XEMBED_FOCUS_IN             4
++#define XEMBED_MODALITY_ON         10
++#define XEMBED_MAPPED              (1 << 0)
++#define XEMBED_WINDOW_ACTIVATE      1
++#define XEMBED_WINDOW_DEACTIVATE    2
++#define VERSION_MAJOR               0
++#define VERSION_MINOR               0
++#define XEMBED_EMBEDDED_VERSION (VERSION_MAJOR << 16) | VERSION_MINOR
+ 
+ /* enums */
+ enum { CurNormal, CurResize, CurMove, CurLast }; /* cursor */
+ enum { SchemeNorm, SchemeSel, SchemeStatus, SchemeTagsSel, SchemeTagsNorm, SchemeInfoSel, SchemeInfoNorm }; /* color schemes */
+ enum { NetSupported, NetWMName, NetWMState, NetWMCheck,
++       NetSystemTray, NetSystemTrayOP, NetSystemTrayOrientation, NetSystemTrayOrientationHorz,
+        NetWMFullscreen, NetWMSticky, NetActiveWindow, NetWMWindowType,
+-       NetWMWindowTypeDialog, NetClientList, NetLast }; /* EWMH atoms (extended window manager hints) */
++       NetWMWindowTypeDialog, NetClientList, NetWMWindowTypeDock, NetWMWindowTypeMenu,
++       NetWMWindowTypeNotification, NetLast }; /* EWMH atoms (extended window manager hints) */
++enum { Manager, Xembed, XembedInfo, XLast }; /* Xembed atoms */
+ enum { WMProtocols, WMDelete, WMState, WMTakeFocus, WMLast }; /* default atoms */
+ enum { ClkTagBar, ClkLtSymbol, ClkStatusText, ClkWinTitle,
+        ClkClientWin, ClkRootWin, ClkLast }; /* clicks */
+@@ -183,6 +198,11 @@ typedef struct {
+ 	int monitor;
+ } Rule;
+ 
++typedef struct Systray   Systray;
++struct Systray {
++	Window win;
++	Client *icons;
++};
+ 
+ /* function declarations */
+ static void applyrules(Client *c);
+@@ -216,11 +236,14 @@ static void focusstack(const Arg *arg);
+ static Atom getatomprop(Client *c, Atom prop);
+ static int getrootptr(int *x, int *y);
+ static long getstate(Window w);
++static unsigned int getsystraywidth();
+ static pid_t getstatusbarpid(void);
+ static void sigstatusbar(const Arg *arg);
+ static int gettextprop(Window w, Atom atom, char *text, unsigned int size);
+ static void grabbuttons(Client *c, int focused);
+ static void grabkeys(void);
++static int ispanel(Client *c);
++static int ispopup(Client *c);
+ static void incnmaster(const Arg *arg);
+ static void keypress(XEvent *e);
+ static void killthis(Client *c);
+@@ -238,13 +261,16 @@ static void propertynotify(XEvent *e);
+ static void pushstack(const Arg *arg);
+ static void quit(const Arg *arg);
+ static Monitor *recttomon(int x, int y, int w, int h);
++static void removesystrayicon(Client *i);
+ static void resize(Client *c, int x, int y, int w, int h, int interact);
++static void resizebarwin(Monitor *m);
+ static void resizeclient(Client *c, int x, int y, int w, int h);
+ static void resizemouse(const Arg *arg);
++static void resizerequest(XEvent *e);
+ static void restack(Monitor *m);
+ static void run(void);
+ static void scan(void);
+-static int sendevent(Client *c, Atom proto);
++static int sendevent(Window w, Atom proto, int m, long d0, long d1, long d2, long d3, long d4);
+ static void sendmon(Client *c, Monitor *m);
+ static void setclientstate(Client *c, long state);
+ static void setfocus(Client *c);
+@@ -256,6 +282,7 @@ static void setup(void);
+ static void seturgent(Client *c, int urg);
+ static void showhide(Client *c);
+ static void spawn(const Arg *arg);
++static Monitor *systraytomon(Monitor *m);
+ static void sighup(int unused);
+ static void sigterm(int unused);
+ static int stackpos(const Arg *arg);
+@@ -283,12 +310,16 @@ static int updategeom(void);
+ static void updatenumlockmask(void);
+ static void updatesizehints(Client *c);
+ static void updatestatus(void);
++static void updatesystray(void);
++static void updatesystrayicongeom(Client *i, int w, int h);
++static void updatesystrayiconstate(Client *i, XPropertyEvent *ev);
+ static void updatetitle(Client *c);
+ static void updatewindowtype(Client *c);
+ static void updatewmhints(Client *c);
+ static void view(const Arg *arg);
+ static Client *wintoclient(Window w);
+ static Monitor *wintomon(Window w);
++static Client *wintosystrayicon(Window w);
+ static int xerror(Display *dpy, XErrorEvent *ee);
+ static int xerrordummy(Display *dpy, XErrorEvent *ee);
+ static int xerrorstart(Display *dpy, XErrorEvent *ee);
+@@ -302,6 +333,7 @@ static Client *termforwin(const Client *c);
+ static pid_t winpid(Window w);
+ 
+ /* variables */
++static Systray *systray = NULL;
+ static const char broken[] = "broken";
+ static char stext[256];
+ static int statusw;
+@@ -327,9 +359,10 @@ static void (*handler[LASTEvent]) (XEvent *) = { /* maps X event type to matchin
+ 	[MapRequest] = maprequest, /* a new window needs to be mapped */
+ 	[MotionNotify] = motionnotify, /* mouse movement */
+ 	[PropertyNotify] = propertynotify, /* window property changes */
++	[ResizeRequest] = resizerequest,
+ 	[UnmapNotify] = unmapnotify /* window needs to be unmapped */
+ };
+-static Atom wmatom[WMLast], netatom[NetLast];
++static Atom wmatom[WMLast], netatom[NetLast], xatom[XLast];
+ static int restart = 0;
+ static int running = 1;
+ static Cur *cursor[CurLast];
+@@ -576,8 +609,8 @@ buttonpress(XEvent *e)
+ 			arg.ui = 1 << i;
+ 		} else if (ev->x < x + TEXTW(selmon->ltsymbol) && selmon->showlayout)
+ 			click = ClkLtSymbol;
+-		else if (ev->x > selmon->ww - statusw && selmon->showstatus) {
+-			x = selmon->ww - statusw;
++		else if (ev->x > selmon->ww - statusw - getsystraywidth() && selmon->showstatus) {
++			x = selmon->ww - statusw - getsystraywidth();
+ 			click = ClkStatusText;
+ 			statussig = 0; /* statuscmd stuff */
+ 			for (text = s = stext; *s && x <= ev->x; s++) { /* loop through to determine which block was clicked */
+@@ -590,8 +623,8 @@ buttonpress(XEvent *e)
+ 					if (x >= ev->x) /* check click pos */
+ 						break;
+ 					statussig = ch; /* save control char as sig # */
+-						}
+ 				}
++			}
+ 		} else if (selmon->showtitle) {
+ 			statussig = 0;
+ 			for (text = s = stext; *s && x <= ev->x; s++) {
+@@ -604,12 +637,12 @@ buttonpress(XEvent *e)
+ 					if (x >= ev->x)
+ 						break;
+ 					statussig = ch;
+-								}
+-						}
++				}
+ 			}
+-		} else
+-			click = ClkWinTitle; 
+-		if ((c = wintoclient(ev->window))) {
++		}
++	} else
++		click = ClkWinTitle; 
++	if ((c = wintoclient(ev->window))) {
+ 		focus(c);
+ 		restack(selmon);
+ 		XAllowEvents(dpy, ReplayPointer, CurrentTime);
+@@ -648,6 +681,13 @@ cleanup(void)
+ 	XUngrabKey(dpy, AnyKey, AnyModifier, root); /* releases all X keybindings */
+ 	while (mons)
+ 		cleanupmon(mons);
++
++	if (showsystray) {
++		XUnmapWindow(dpy, systray->win);
++		XDestroyWindow(dpy, systray->win);
++		free(systray);
++	}
++
+ 	for (i = 0; i < CurLast; i++)
+ 		drw_cur_free(drw, cursor[i]);
+ 	for (i = 0; i < LENGTH(colors); i++)
+@@ -679,20 +719,70 @@ cleanupmon(Monitor *mon)
+ void
+ clientmessage(XEvent *e)
+ {
++	XWindowAttributes wa;
++	XSetWindowAttributes swa;
+ 	XClientMessageEvent *cme = &e->xclient;
+ 	Client *c = wintoclient(cme->window);
+ 
++	if (showsystray && cme->window == systray->win && cme->message_type == netatom[NetSystemTrayOP]) {
++		/* add systray icons */
++		if (cme->data.l[1] == SYSTEM_TRAY_REQUEST_DOCK) {
++			if (!(c = (Client *)calloc(1, sizeof(Client))))
++				die("fatal: could not malloc() %u bytes\n", sizeof(Client));
++			if (!(c->win = cme->data.l[2])) {
++				free(c);
++				return;
++			}
++			c->mon = selmon;
++			c->next = systray->icons;
++			systray->icons = c;
++			if (!XGetWindowAttributes(dpy, c->win, &wa)) {
++				/* use sane defaults */
++				wa.width = bh;
++				wa.height = bh;
++				wa.border_width = 0;
++			}
++			c->x = c->oldx = c->y = c->oldy = 0;
++			c->w = c->oldw = wa.width;
++			c->h = c->oldh = wa.height;
++			c->oldbw = wa.border_width;
++			c->bw = 0;
++			c->isfloating = True;
++			/* reuse tags field as mapped status */
++			c->tags = 1;
++			updatesizehints(c);
++			updatesystrayicongeom(c, wa.width, wa.height);
++			XAddToSaveSet(dpy, c->win);
++			XSelectInput(dpy, c->win, StructureNotifyMask | PropertyChangeMask | ResizeRedirectMask);
++			XReparentWindow(dpy, c->win, systray->win, 0, 0);
++			/* use parents background color */
++			swa.background_pixel  = scheme[SchemeNorm][ColBg].pixel;
++			XChangeWindowAttributes(dpy, c->win, CWBackPixel, &swa);
++			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_EMBEDDED_NOTIFY, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
++			/* FIXME not sure if I have to send these events, too */
++			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_FOCUS_IN, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
++			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_WINDOW_ACTIVATE, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
++			sendevent(c->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_MODALITY_ON, 0 , systray->win, XEMBED_EMBEDDED_VERSION);
++			XSync(dpy, False);
++			resizebarwin(selmon);
++			updatesystray();
++			setclientstate(c, NormalState);
++		}
++		return;
++	}
++
++
+ 	if (!c)
+ 		return;
+ 	if (cme->message_type == netatom[NetWMState]) {
+ 		if (cme->data.l[1] == netatom[NetWMFullscreen]
+ 		|| cme->data.l[2] == netatom[NetWMFullscreen])
+-			setfullscreen(c, (cme->data.l[0] == 1 /* _NET_WM_STATE_ADD    */
+-				|| (cme->data.l[0] == 2 /* _NET_WM_STATE_TOGGLE */ && !c->isfullscreen)));
++			setfullscreen(c, (cme->data.l[0] == 1
++				|| (cme->data.l[1] == 2 && !c->isfullscreen)));
+ 
+-        if (cme->data.l[1] == netatom[NetWMSticky]
+-                || cme->data.l[2] == netatom[NetWMSticky])
+-            setsticky(c, (cme->data.l[0] == 1 || (cme->data.l[0] == 2 && !c->issticky)));
++		if (cme->data.l[1] == netatom[NetWMSticky]
++				|| cme->data.l[2] == netatom[NetWMSticky])
++			setsticky(c, (cme->data.l[0] == 1 || (cme->data.l[0] == 2 && !c->issticky)));
+ 	} else if (cme->message_type == netatom[NetActiveWindow]) {
+ 		if (c != selmon->sel && !c->isurgent)
+ 			seturgent(c, 1);
+@@ -738,7 +828,7 @@ configurenotify(XEvent *e)
+ 				for (c = m->clients; c; c = c->next)
+ 					if (c->isfullscreen)
+ 						resizeclient(c, m->mx, m->my, m->mw, m->mh);
+-				XMoveResizeWindow(dpy, m->barwin, m->wx, m->by, m->ww, bh);
++				resizebarwin(m);
+ 			}
+ 			focus(NULL);
+ 			arrange(NULL);
+@@ -833,6 +923,12 @@ destroynotify(XEvent *e)
+ 	if ((c = wintoclient(ev->window)))
+ 		unmanage(c, 1);
+ 
++	else if ((c = wintosystrayicon(ev->window))) {
++		removesystrayicon(c);
++		resizebarwin(selmon);
++		updatesystray();
++	}
++
+ 	else if ((c = swallowingclient(ev->window)))
+ 		unmanage(c->swallowing, 1);
+ }
+@@ -882,7 +978,7 @@ dirtomon(int dir)
+ void
+ drawbar(Monitor *m) /* take a pointer to the monitor we want to draw the bar on */
+ {
+-	int x, w, tw = 0; /* x pos, width, and text width */
++	int x, w, tw = 0, stw = 0; /* x pos, width, text width, and systray width */
+ 	int boxs = drw->fonts->h / 9; /* the little square box for indicators */
+ 	int boxw = drw->fonts->h / 6 + 2;
+ 	unsigned int i, occ = 0, urg = 0; /* track which tags are in use and which are urgent */
+@@ -891,6 +987,9 @@ drawbar(Monitor *m) /* take a pointer to the monitor we want to draw the bar on
+ 	if (!m->showbar) /* if the bar is hidden, do not draw it */
+ 		return;
+ 
++	if(showsystray && m == systraytomon(m) && !systrayonleft)
++		stw = getsystraywidth();
++
+ 	/* draw status first so it can be overdrawn by tags later */
+ 	if (m == selmon && selmon->showstatus) { /* status is only drawn on selected monitor */
+ 		char *text, *s, ch;
+@@ -901,18 +1000,23 @@ drawbar(Monitor *m) /* take a pointer to the monitor we want to draw the bar on
+ 				ch = *s;
+ 				*s = '\0';
+ 				tw = TEXTW(text) - lrpad;
+-				drw_text(drw, m->ww - statusw + x, 0, tw, bh, 0, text, 0);
++				drw_text(drw, m->ww - statusw  + x - stw, 0, tw, bh, 0, text, 0);				
+ 				x += tw;
+ 				*s = ch;
+ 				text = s + 1;
+ 			}
+ 		}
+-		tw = TEXTW(text) - lrpad + 2; /* draw the last remaining segment after the last ctrl char */
+-		drw_text(drw, m->ww - statusw + x, 0, tw, bh, 0, text, 0);
+-		tw = statusw; 
++		tw = TEXTW(text) - lrpad + 2; /* 2px extra right padding */
++		drw_text(drw, m->ww - statusw + x - stw, 0, tw, bh, 0 , text, 0);
++		tw = statusw;
+ 	}
+ 
++	resizebarwin(m);
++
+ 	for (c = m->clients; c; c = c->next) { /* drawing tag indicators */
++		// preven tshowing the panel as active application
++		if (ispanel(c))
++			continue;
+ 		occ |= c->tags == TAGMASK ? 0 : c->tags; /* if a client has all tags, skip it */
+ 		if (c->isurgent && selmon->showtags)
+ 			urg |= c->tags;
+@@ -941,7 +1045,7 @@ drawbar(Monitor *m) /* take a pointer to the monitor we want to draw the bar on
+ 	}
+ 
+ 
+-	if ((w = m->ww - tw - x) > bh) {
++	if ((w = m->ww - tw - stw - x) > bh) {
+ 		if (m->sel && selmon->showtitle) {
+ 			drw_setscheme(drw, scheme[m == selmon ? SchemeInfoSel : SchemeInfoNorm]);
+ 			drw_text(drw, x, 0, w, bh, lrpad / 2, m->sel->name, 0);
+@@ -952,7 +1056,7 @@ drawbar(Monitor *m) /* take a pointer to the monitor we want to draw the bar on
+ 			drw_rect(drw, x, 0, w, bh, 1, 1);
+ 		}
+ 	}
+-	drw_map(drw, m->barwin, 0, 0, m->ww, bh);
++	drw_map(drw, m->barwin, 0, 0, m->ww - stw, bh);
+ }
+ 
+ void
+@@ -989,8 +1093,11 @@ expose(XEvent *e)
+ 	Monitor *m;
+ 	XExposeEvent *ev = &e->xexpose;
+ 
+-	if (ev->count == 0 && (m = wintomon(ev->window)))
++	if (ev->count == 0 && (m = wintomon(ev->window))) {
+ 		drawbar(m);
++		if (m == selmon)
++			updatesystray();
++	}
+ }
+ 
+ void
+@@ -1005,11 +1112,14 @@ focus(Client *c)
+ 			selmon = c->mon; /* switch selmon (selected monitor) to that monitor */
+ 		if (c->isurgent) /* if urgent state was marked, */
+ 			seturgent(c, 0); /* clear urgent state */
+-		detachstack(c);
+-		attachstack(c); /* move c to top of the stack */
+-		grabbuttons(c, 1);
+-		XSetWindowBorder(dpy, c->win, scheme[SchemeSel][ColBorder].pixel);
+-		setfocus(c); /* inform X11 that c now has input focus */
++		// prevents the pnel getting focus when tag switching:
++		if (!ispanel(c)) {
++		    detachstack(c);
++		    attachstack(c); /* move c to top of the stack */
++		    grabbuttons(c, 1);
++		    XSetWindowBorder(dpy, c->win, scheme[SchemeSel][ColBorder].pixel);
++		    setfocus(c); /* inform X11 that c now has input focus */
++		}
+ 	} else {
+ 		XSetInputFocus(dpy, selmon->barwin, RevertToPointerRoot, CurrentTime);
+ 		XDeleteProperty(dpy, root, netatom[NetActiveWindow]);
+@@ -1077,6 +1187,7 @@ focusmon(const Arg *arg)
+ 	focus(NULL);
+ }
+ 
++int focussed_panel = 0; // helper for focusstack, avoids loops when panel is the only client
+ void
+ focusstack(const Arg *arg)
+ {
+@@ -1089,6 +1200,12 @@ focusstack(const Arg *arg)
+ 	    i -= ISVISIBLE(c) ? 1 : 0, p = c, c = c->next);
+ 	focus(c ? c : p);
+ 	restack(selmon);
++
++	if (ispanel(c) && focussed_panel == 0) {
++	    focussed_panel = 1;
++	    focusstack(arg);
++	    focussed_panel = 0;
++	}
+ }
+ 
+ Atom
+@@ -1099,9 +1216,17 @@ getatomprop(Client *c, Atom prop)
+ 	unsigned char *p = NULL;
+ 	Atom da, atom = None;
+ 
+-	if (XGetWindowProperty(dpy, c->win, prop, 0L, sizeof atom, False, XA_ATOM,
++	/* FIXME getatomprop should return the number of items and a pointer to
++	 * the stored data instead of this workaround */
++	Atom req = XA_ATOM;
++	if (prop == xatom[XembedInfo])
++		req = xatom[XembedInfo];
++
++	if (XGetWindowProperty(dpy, c->win, prop, 0L, sizeof atom, False, req,
+ 		&da, &di, &dl, &dl, &p) == Success && p) {
+ 		atom = *(Atom *)p;
++		if (da == xatom[XembedInfo] && dl == 2)
++			atom = ((Atom *)p)[1];
+ 		XFree(p);
+ 	}
+ 	return atom;
+@@ -1139,6 +1264,16 @@ getstatusbarpid(void)
+ 	return strtol(buf, NULL, 10);
+ }
+ 
++unsigned int
++getsystraywidth()
++{
++	unsigned int w = 0;
++	Client *i;
++	if(showsystray)
++		for(i = systray->icons; i; w += i->w + systrayspacing, i = i->next) ;
++	return w ? w + systrayspacing : 1;
++}
++
+ 
+ int
+ getrootptr(int *x, int *y)
+@@ -1240,6 +1375,19 @@ grabkeys(void)
+ 	}
+ }
+ 
++int
++ispanel(Client *c) {
++    return !strcmp(c->name, panel[0]);
++}
++
++int
++ispopup(Client *c) {
++	Atom wtype = getatomprop(c, netatom[NetWMWindowType]);
++	return (wtype == netatom[NetWMWindowTypeDialog] ||
++		 wtype == netatom[NetWMWindowTypeNotification] ||
++		 wtype == netatom[NetWMWindowTypeMenu]);
++}
++
+ void
+ incnmaster(const Arg *arg)
+ {
+@@ -1277,7 +1425,7 @@ keypress(XEvent *e) /* receives a keyboard press XEvent from X11 */
+ 
+ void
+ killthis(Client *c) {
+-	if (!sendevent(c, wmatom[WMDelete])) {
++	if (!sendevent(selmon->sel->win, wmatom[WMDelete], NoEventMask, wmatom[WMDelete], CurrentTime, 0 , 0, 0)) {
+ 		XGrabServer(dpy);
+ 		XSetErrorHandler(xerrordummy);
+ 		XSetCloseDownMode(dpy, DestroyAll);
+@@ -1374,6 +1522,8 @@ manage(Window w, XWindowAttributes *wa)
+ 	c->y = MAX(c->y, c->mon->wy);
+ 	c->bw = borderpx;
+ 
++    // no border - even when active
++    if (ispanel(c)) c->bw = c->oldbw = 0;
+ 	wc.border_width = c->bw;
+ 	XConfigureWindow(dpy, w, CWBorderWidth, &wc);
+ 	XSetWindowBorder(dpy, w, scheme[SchemeNorm][ColBorder].pixel);
+@@ -1393,8 +1543,8 @@ manage(Window w, XWindowAttributes *wa)
+ 		(unsigned char *) &(c->win), 1);
+ 	XMoveResizeWindow(dpy, c->win, c->x + 2 * sw, c->y, c->w, c->h); /* some windows require this */
+ 	setclientstate(c, NormalState);
+-	if(selmon->sel && selmon->sel->isfullscreen && !c->isfloating) /* if a fullscreen window was focused, toggle fullscreen */
+-		setfullscreen(selmon->sel, 0);
++	//if(selmon->sel && selmon->sel->isfullscreen && !c->isfloating) /* if a fullscreen window was focused, toggle fullscreen */
++	//	setfullscreen(selmon->sel, 0);
+ 	if (c->mon == selmon)
+ 		unfocus(selmon->sel, 0); /* unfocus other monitor if new window is on current monitor */
+ 	c->mon->sel = c;
+@@ -1421,6 +1571,13 @@ maprequest(XEvent *e)
+ 	static XWindowAttributes wa; /* wa will now hold window attributes */
+ 	XMapRequestEvent *ev = &e->xmaprequest;
+ 
++	Client *i;
++	if ((i = wintosystrayicon(ev->window))) {
++		sendevent(i->win, netatom[Xembed], StructureNotifyMask, CurrentTime, XEMBED_WINDOW_ACTIVATE, 0, systray->win, XEMBED_EMBEDDED_VERSION);
++		resizebarwin(selmon);
++		updatesystray();
++	}
++
+ 	if (!XGetWindowAttributes(dpy, ev->window, &wa) || wa.override_redirect)
+ 		return; /* gets window geom and data */
+ 	if (!wintoclient(ev->window)) /* if window is not already managed by dwm */
+@@ -1547,6 +1704,17 @@ propertynotify(XEvent *e)
+ 	Window trans;
+ 	XPropertyEvent *ev = &e->xproperty;
+ 
++	if ((c = wintosystrayicon(ev->window))) {
++		if (ev->atom == XA_WM_NORMAL_HINTS) {
++			updatesizehints(c);
++			updatesystrayicongeom(c, c->w, c->h);
++		}
++		else
++			updatesystrayiconstate(c, ev);
++		resizebarwin(selmon);
++		updatesystray();
++	}
++
+ 	if ((ev->window == root) && (ev->atom == XA_WM_NAME))
+ 		updatestatus();
+ 	else if (ev->state == PropertyDelete)
+@@ -1621,13 +1789,34 @@ recttomon(int x, int y, int w, int h)
+ 	return r;
+ }
+ 
++void
++removesystrayicon(Client *i)
++{
++	Client **ii;
++
++	if (!showsystray || !i)
++		return;
++	for (ii = &systray->icons; *ii && *ii != i; ii = &(*ii)->next);
++	if (ii)
++		*ii = i->next;
++	free(i);
++}
++
+ void
+ resize(Client *c, int x, int y, int w, int h, int interact)
+ {
+-	if (applysizehints(c, &x, &y, &w, &h, interact))
++	if (ispanel(c) || applysizehints(c, &x, &y, &w, &h, interact))
+ 		resizeclient(c, x, y, w, h);
+ }
+ 
++void
++resizebarwin(Monitor *m) {
++	unsigned int w = m->ww;
++	if (showsystray && m == systraytomon(m) && !systrayonleft)
++		w -= getsystraywidth();
++	XMoveResizeWindow(dpy, m->barwin, m->wx, m->by, w, bh);
++}
++
+ void
+ resizeclient(Client *c, int x, int y, int w, int h)
+ {
+@@ -1638,11 +1827,26 @@ resizeclient(Client *c, int x, int y, int w, int h)
+ 	c->oldw = c->w; c->w = wc.width = w;
+ 	c->oldh = c->h; c->h = wc.height = h;
+ 	wc.border_width = c->bw;
++    // nail it to no border & y=0:
++    if (ispanel(c)) c->y = c->oldy = c->bw = wc.y = wc.border_width = 0;
+ 	XConfigureWindow(dpy, c->win, CWX|CWY|CWWidth|CWHeight|CWBorderWidth, &wc);
+ 	configure(c);
+ 	XSync(dpy, False);
+ }
+ 
++void
++resizerequest(XEvent *e)
++{
++	XResizeRequestEvent *ev = &e->xresizerequest;
++	Client *i;
++
++	if ((i = wintosystrayicon(ev->window))) {
++		updatesystrayicongeom(i, ev->width, ev->height);
++		resizebarwin(selmon);
++		updatesystray();
++	}
++}
++
+ void
+ resizemouse(const Arg *arg)
+ {
+@@ -1789,26 +1993,37 @@ setclientstate(Client *c, long state)
+ }
+ 
+ int
+-sendevent(Client *c, Atom proto)
++sendevent(Window w, Atom proto, int mask, long d0, long d1, long d2, long d3, long d4)
+ {
+ 	int n;
+-	Atom *protocols;
++	Atom *protocols, mt;
+ 	int exists = 0;
+ 	XEvent ev;
+ 
+-	if (XGetWMProtocols(dpy, c->win, &protocols, &n)) {
+-		while (!exists && n--)
+-			exists = protocols[n] == proto;
+-		XFree(protocols);
++	if (proto == wmatom[WMTakeFocus] || proto == wmatom[WMDelete]) {
++		mt = wmatom[WMProtocols];
++		if (XGetWMProtocols(dpy, w, &protocols, &n)) {
++			while (!exists && n--)
++				exists = protocols[n] == proto;
++			XFree(protocols);
++		}
++	}
++	else {
++		exists = True;
++		mt = proto;
+ 	}
++
+ 	if (exists) {
+ 		ev.type = ClientMessage;
+-		ev.xclient.window = c->win;
+-		ev.xclient.message_type = wmatom[WMProtocols];
++		ev.xclient.window = w;
++		ev.xclient.message_type = mt;		
+ 		ev.xclient.format = 32;
+-		ev.xclient.data.l[0] = proto;
+-		ev.xclient.data.l[1] = CurrentTime;
+-		XSendEvent(dpy, c->win, False, NoEventMask, &ev);
++		ev.xclient.data.l[0] = d0;
++		ev.xclient.data.l[1] = d1;
++		ev.xclient.data.l[2] = d2;
++		ev.xclient.data.l[3] = d3;
++		ev.xclient.data.l[4] = d4;
++		XSendEvent(dpy, w, False, mask, &ev);		
+ 	}
+ 	return exists;
+ }
+@@ -1822,12 +2037,15 @@ setfocus(Client *c)
+ 			XA_WINDOW, 32, PropModeReplace,
+ 			(unsigned char *) &(c->win), 1);
+ 	}
+-	sendevent(c, wmatom[WMTakeFocus]);
++	sendevent(c->win, wmatom[WMTakeFocus], NoEventMask, wmatom[WMTakeFocus], CurrentTime, 0, 0, 0);
+ }
+ 
+ void
+ setfullscreen(Client *c, int fullscreen)
+ {
++	if (ispopup(c))
++		return;
++
+ 	if (fullscreen && !c->isfullscreen) {
+ 		XChangeProperty(dpy, c->win, netatom[NetWMState], XA_ATOM, 32,
+ 			PropModeReplace, (unsigned char*)&netatom[NetWMFullscreen], 1);
+@@ -1942,6 +2160,10 @@ setup(void)
+ 	wmatom[WMTakeFocus] = XInternAtom(dpy, "WM_TAKE_FOCUS", False);
+ 	netatom[NetActiveWindow] = XInternAtom(dpy, "_NET_ACTIVE_WINDOW", False);
+ 	netatom[NetSupported] = XInternAtom(dpy, "_NET_SUPPORTED", False);
++	netatom[NetSystemTray] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_S0", False);
++	netatom[NetSystemTrayOP] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_OPCODE", False);
++	netatom[NetSystemTrayOrientation] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_ORIENTATION", False);
++	netatom[NetSystemTrayOrientationHorz] = XInternAtom(dpy, "_NET_SYSTEM_TRAY_ORIENTATION_HORZ", False);	
+ 	netatom[NetWMName] = XInternAtom(dpy, "_NET_WM_NAME", False);
+ 	netatom[NetWMState] = XInternAtom(dpy, "_NET_WM_STATE", False);
+ 	netatom[NetWMCheck] = XInternAtom(dpy, "_NET_SUPPORTING_WM_CHECK", False);
+@@ -1949,7 +2171,13 @@ setup(void)
+ 	netatom[NetWMSticky] = XInternAtom(dpy, "_NET_WM_STATE_STICKY", False);
+ 	netatom[NetWMWindowType] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE", False);
+ 	netatom[NetWMWindowTypeDialog] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DIALOG", False);
++	netatom[NetWMWindowTypeDock] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_DOCK", False);
++	netatom[NetWMWindowTypeMenu] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_MENU", False);
++	netatom[NetWMWindowTypeNotification] = XInternAtom(dpy, "_NET_WM_WINDOW_TYPE_NOTIFICATION", False);
+ 	netatom[NetClientList] = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
++	xatom[Manager] = XInternAtom(dpy, "MANAGER", False);
++	xatom[Xembed] = XInternAtom(dpy, "_XEMBED", False);
++	xatom[XembedInfo] = XInternAtom(dpy, "_XEMBED_INFO", False);	
+ 	/* init cursors */
+ 	cursor[CurNormal] = drw_cur_create(drw, XC_left_ptr);
+ 	cursor[CurResize] = drw_cur_create(drw, XC_sizing);
+@@ -1958,6 +2186,8 @@ setup(void)
+ 	scheme = ecalloc(LENGTH(colors), sizeof(Clr *)); /* allocates memory to set up colorschemes */
+ 	for (i = 0; i < LENGTH(colors); i++)
+ 		scheme[i] = drw_scm_create(drw, colors[i], 3); /* each scheme[i] corresponds to a SchemeNorm, SchemeSel, etc */
++	/* init system tray */
++	updatesystray();	
+ 	/* init bars */
+ 	updatebars(); /* creates a bar window for each monitor */
+ 	updatestatus(); /* renders the status text */
+@@ -2204,7 +2434,18 @@ togglebar(const Arg *arg)
+ {
+ 	selmon->showbar = !selmon->showbar;
+ 	updatebarpos(selmon);
+-	XMoveResizeWindow(dpy, selmon->barwin, selmon->wx, selmon->by, selmon->ww, bh);
++	resizebarwin(selmon);
++	if (showsystray) {
++		XWindowChanges wc;
++		if (!selmon->showbar)
++			wc.y = -bh;
++		else if (selmon->showbar) {
++			wc.y = 0;
++			if (!selmon->topbar)
++				wc.y = selmon->mh - bh;
++		}
++		XConfigureWindow(dpy, systray->win, CWY, &wc);
++	}	
+ 	arrange(selmon);
+ }
+ 
+@@ -2389,11 +2630,18 @@ unmapnotify(XEvent *e)
+ 		else
+ 			unmanage(c, 0);
+ 	}
++	else if ((c = wintosystrayicon(ev->window))) {
++		/* KLUDGE! sometimes icons occasionally unmap their windows, but do
++		 * _not_ destroy them. We map those windows back */
++		XMapRaised(dpy, c->win);
++		updatesystray();
++	}	
+ }
+ 
+ void
+ updatebars(void)
+ {
++	unsigned int w;	
+ 	Monitor *m;
+ 	XSetWindowAttributes wa = {
+ 		.override_redirect = True,
+@@ -2404,10 +2652,15 @@ updatebars(void)
+ 	for (m = mons; m; m = m->next) {
+ 		if (m->barwin)
+ 			continue;
+-		m->barwin = XCreateWindow(dpy, root, m->wx, m->by, m->ww, bh, 0, DefaultDepth(dpy, screen),
++		w = m->ww;
++		if (showsystray && m == systraytomon(m))
++			w -= getsystraywidth();
++		m->barwin = XCreateWindow(dpy, root, m->wx, m->by, w, bh, 0, DefaultDepth(dpy, screen),
+ 				CopyFromParent, DefaultVisual(dpy, screen),
+ 				CWOverrideRedirect|CWBackPixmap|CWEventMask, &wa);
+ 		XDefineCursor(dpy, m->barwin, cursor[CurNormal]->cursor);
++		if (showsystray && m == systraytomon(m))
++			XMapRaised(dpy, systray->win);	
+ 		XMapRaised(dpy, m->barwin);
+ 		XSetClassHint(dpy, m->barwin, &ch);
+ 	}
+@@ -2582,7 +2835,7 @@ void
+ updatestatus(void)
+ {
+ 	if (!gettextprop(root, XA_WM_NAME, stext, sizeof(stext)) && selmon->showstatus) {
+-		strcpy(stext, "dwm-"VERSION);
++		strcpy(stext, ""); // no shining of dwm version thru pnel, when transparent
+ 		statusw = TEXTW(stext) - lrpad + 2;
+ 	} else {
+ 		char *text, *s, ch;
+@@ -2601,6 +2854,125 @@ updatestatus(void)
+ 
+ 	}
+ 	drawbar(selmon);
++	updatesystray();
++}
++
++
++void
++updatesystrayicongeom(Client *i, int w, int h)
++{
++	if (i) {
++		i->h = bh;
++		if (w == h)
++			i->w = bh;
++		else if (h == bh)
++			i->w = w;
++		else
++			i->w = (int) ((float)bh * ((float)w / (float)h));
++		applysizehints(i, &(i->x), &(i->y), &(i->w), &(i->h), False);
++		/* force icons into the systray dimensions if they don't want to */
++		if (i->h > bh) {
++			if (i->w == i->h)
++				i->w = bh;
++			else
++				i->w = (int) ((float)bh * ((float)i->w / (float)i->h));
++			i->h = bh;
++		}
++	}
++}
++
++void
++updatesystrayiconstate(Client *i, XPropertyEvent *ev)
++{
++	long flags;
++	int code = 0;
++
++	if (!showsystray || !i || ev->atom != xatom[XembedInfo] ||
++			!(flags = getatomprop(i, xatom[XembedInfo])))
++		return;
++
++	if (flags & XEMBED_MAPPED && !i->tags) {
++		i->tags = 1;
++		code = XEMBED_WINDOW_ACTIVATE;
++		XMapRaised(dpy, i->win);
++		setclientstate(i, NormalState);
++	}
++	else if (!(flags & XEMBED_MAPPED) && i->tags) {
++		i->tags = 0;
++		code = XEMBED_WINDOW_DEACTIVATE;
++		XUnmapWindow(dpy, i->win);
++		setclientstate(i, WithdrawnState);
++	}
++	else
++		return;
++	sendevent(i->win, xatom[Xembed], StructureNotifyMask, CurrentTime, code, 0,
++			systray->win, XEMBED_EMBEDDED_VERSION);
++}
++
++void
++updatesystray(void)
++{
++	XSetWindowAttributes wa;
++	XWindowChanges wc;
++	Client *i;
++	Monitor *m = systraytomon(NULL);
++	unsigned int x = m->mx + m->mw;
++	unsigned int sw = TEXTW(stext) - lrpad + systrayspacing;
++	unsigned int w = 1;
++
++	if (!showsystray)
++		return;
++	if (systrayonleft)
++		x -= sw + lrpad / 2;
++	if (!systray) {
++		/* init systray */
++		if (!(systray = (Systray *)calloc(1, sizeof(Systray))))
++			die("fatal: could not malloc() %u bytes\n", sizeof(Systray));
++		systray->win = XCreateSimpleWindow(dpy, root, x, m->by, w, bh, 0, 0, scheme[SchemeSel][ColBg].pixel);
++		wa.event_mask        = ButtonPressMask | ExposureMask;
++		wa.override_redirect = True;
++		wa.background_pixel  = scheme[SchemeNorm][ColBg].pixel;
++		XSelectInput(dpy, systray->win, SubstructureNotifyMask);
++		XChangeProperty(dpy, systray->win, netatom[NetSystemTrayOrientation], XA_CARDINAL, 32,
++				PropModeReplace, (unsigned char *)&netatom[NetSystemTrayOrientationHorz], 1);
++		XChangeWindowAttributes(dpy, systray->win, CWEventMask|CWOverrideRedirect|CWBackPixel, &wa);
++		XMapRaised(dpy, systray->win);
++		XSetSelectionOwner(dpy, netatom[NetSystemTray], systray->win, CurrentTime);
++		if (XGetSelectionOwner(dpy, netatom[NetSystemTray]) == systray->win) {
++			sendevent(root, xatom[Manager], StructureNotifyMask, CurrentTime, netatom[NetSystemTray], systray->win, 0, 0);
++			XSync(dpy, False);
++		}
++		else {
++			fprintf(stderr, "dwm: unable to obtain system tray.\n");
++			free(systray);
++			systray = NULL;
++			return;
++		}
++	}
++	for (w = 0, i = systray->icons; i; i = i->next) {
++		/* make sure the background color stays the same */
++		wa.background_pixel  = scheme[SchemeNorm][ColBg].pixel;
++		XChangeWindowAttributes(dpy, i->win, CWBackPixel, &wa);
++		XMapRaised(dpy, i->win);
++		w += systrayspacing;
++		i->x = w;
++		XMoveResizeWindow(dpy, i->win, i->x, 0, i->w, i->h);
++		w += i->w;
++		if (i->mon != m)
++			i->mon = m;
++	}
++	w = w ? w + systrayspacing : 1;
++	x -= w;
++	XMoveResizeWindow(dpy, systray->win, x, m->by, w, bh);
++	wc.x = x; wc.y = m->by; wc.width = w; wc.height = bh;
++	wc.stack_mode = Above; wc.sibling = m->barwin;
++	XConfigureWindow(dpy, systray->win, CWX|CWY|CWWidth|CWHeight|CWSibling|CWStackMode, &wc);
++	XMapWindow(dpy, systray->win);
++	XMapSubwindows(dpy, systray->win);
++	/* redraw background */
++	XSetForeground(dpy, drw->gc, scheme[SchemeNorm][ColBg].pixel);
++	XFillRectangle(dpy, systray->win, drw->gc, 0, 0, w, bh);
++	XSync(dpy, False);
+ }
+ 
+ void
+@@ -2616,15 +2988,16 @@ void
+ updatewindowtype(Client *c)
+ {
+ 	Atom state = getatomprop(c, netatom[NetWMState]);
+-	Atom wtype = getatomprop(c, netatom[NetWMWindowType]);
+-
+-	if (state == netatom[NetWMFullscreen])
++	
++	int is_popup = ispopup(c);
++	if (!c->isfullscreen && state == netatom[NetWMFullscreen] && !is_popup)
+ 		setfullscreen(c, 1);
+ 	if (state == netatom[NetWMSticky]) {
+ 		setsticky(c, 1);
+ 	}
+-	if (wtype == netatom[NetWMWindowTypeDialog])
++	if (is_popup) {
+ 		c->isfloating = 1;
++	}
+ }
+ 
+ void
+@@ -2813,6 +3186,16 @@ wintoclient(Window w)
+ 	return NULL;
+ }
+ 
++Client *
++wintosystrayicon(Window w) {
++	Client *i = NULL;
++
++	if (!showsystray || !w)
++		return i;
++	for (i = systray->icons; i && i->win != w; i = i->next) ;
++	return i;
++}
++
+ Monitor *
+ wintomon(Window w)
+ { /* move window w to monitor m */
+@@ -2830,6 +3213,22 @@ wintomon(Window w)
+ 	return selmon;
+ }
+ 
++Monitor *
++systraytomon(Monitor *m) {
++	Monitor *t;
++	int i, n;
++	if(!systraypinning) {
++		if(!m)
++			return selmon;
++		return m == selmon ? m : NULL;
++	}
++	for(n = 1, t = mons; t && t->next; n++, t = t->next) ;
++	for(i = 1, t = mons; t && t->next && i < systraypinning; i++, t = t->next) ;
++	if(systraypinningfailfirst && n < systraypinning)
++		return mons;
++	return t;
++}
++
+ /* There's no way to check accesses to destroyed windows, thus those cases are
+  * ignored (especially on UnmapNotify's). Other types of errors call Xlibs
+  * default error handler, which may call exit. */
+@@ -2839,6 +3238,7 @@ xerror(Display *dpy, XErrorEvent *ee)
+ 	if (ee->error_code == BadWindow
+ 	|| (ee->request_code == X_SetInputFocus && ee->error_code == BadMatch)
+ 	|| (ee->request_code == X_PolyText8 && ee->error_code == BadDrawable)
++	|| (ee->request_code == X_PolyText8 && ee->error_code == BadDrawable)
+ 	|| (ee->request_code == X_PolyFillRectangle && ee->error_code == BadDrawable)
+ 	|| (ee->request_code == X_PolySegment && ee->error_code == BadDrawable)
+ 	|| (ee->request_code == X_ConfigureWindow && ee->error_code == BadMatch)


### PR DESCRIPTION
Added [dwm-systray-20230922-9f88553.diff](https://dwm.suckless.org/patches/systray/dwm-systray-20230922-9f88553.diff) as an optional patch.
Updated to this fork + merged with statuscmd (thus works with dwmblocks).

<img width="289" height="60" alt="2026-01-02_18-04" src="https://github.com/user-attachments/assets/c6dd9340-50d4-43e4-9fcf-428d60167ef9" />

Finally with fixed padding :)
